### PR TITLE
Update install instructions required for running the tutorial examples

### DIFF
--- a/docs/environment-docs.yml
+++ b/docs/environment-docs.yml
@@ -7,7 +7,7 @@ dependencies:
   - sphinx_rtd_theme>=3.0
   - freud >=3.0
   - gsd >=3.0
-  - hoomd >=5.0
+  - hoomd >=5.0,<5.4
   - python >=3.10
   - pandas
   - numpy >=2.0

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,7 +10,7 @@ Install from anaconda
 msibi is available on `conda-forge <https://anaconda.org/conda-forge/msibi>`_
 ::
 
-    $ mamba install -c conda-forge msibi
+    $ conda install -c conda-forge msibi
 
 
 Install from source
@@ -25,8 +25,8 @@ Install from source
 2. Install dependency packages and msibi from source:
 ::
 
-    $ mamba env create -f environment.yml
-    $ mamba activate msibi
+    $ conda env create -f environment.yml
+    $ conda activate msibi
     $ python -m pip install .
 
 .. note::

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,6 +3,19 @@ Tutorials
 
 Here are some tutorials which go further in depth into MSIBI use cases. For quick-start examples of code using MSIBI's API see :doc:`examples`.
 
+The introduction tutorial uses `.gsd` files that are stored in the source repository. These are not packaged with the
+conda-forge distribution of `msibi`, and depending on how you installed `msibi` from source, they may or may not be accessible. To ensure these files are accessible when running this tutorial, please use the following installation steps.
+
+This uses the `anaconda package manager <https://www.anaconda.com/download>`_.
+
+.. code-block:: bash
+
+   git clone https://github.com/mosdef-hub/msibi
+   cd msibi
+   conda env create -f environment.yml python=3.13 jupyter
+   conda activate msibi
+   pip install -e .
+
 .. toctree::
     :maxdepth: 1
 

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -3,7 +3,7 @@ Tutorials
 
 Here are some tutorials which go further in depth into MSIBI use cases. For quick-start examples of code using MSIBI's API see :doc:`examples`.
 
-The introduction tutorial uses `.gsd` files that are stored in the source repository. These are not packaged with the
+The introduction tutorial uses `.gsd` `files <https://github.com/mosdef-hub/msibi/tree/main/msibi/tests/validation/target_data>`_ that are stored in the source repository. These are not packaged with the
 conda-forge distribution of `msibi`, and depending on how you installed `msibi` from source, they may or may not be accessible. To ensure these files are accessible when running this tutorial, please use the following installation steps.
 
 This uses the `anaconda package manager <https://www.anaconda.com/download>`_.

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
 - cmeutils >=1.4
 - freud >=3.4
 - gsd >=3.0
-- hoomd >=5.0
+- hoomd >=5.0,<5.4
 - python >=3.10,<=3.13
 - pandas
 - numpy >=2.0,<2.3

--- a/environment.yml
+++ b/environment.yml
@@ -5,8 +5,8 @@ dependencies:
 - freud >=3.4
 - cmeutils >=1.4
 - gsd >=3.0
-- hoomd >=5.0
-- matplotlob
+- hoomd >=5.0,<5.4
+- matplotlib
 - python >=3.10,<=3.13
 - pandas
 - mdanalysis <3.0


### PR DESCRIPTION
The tutorials require files stored in the repo that aren't packaged. Running the tutorials without error requires specific a installation. This PR adds an explanation and instructions in the tutorials section of the docs.